### PR TITLE
Suppression du doublon 'L'Opinion'

### DIFF
--- a/medias_francais.tsv
+++ b/medias_francais.tsv
@@ -50,7 +50,6 @@ Investir	Média	3		GPE	Hebdomadaire
 Investir Magazine	Média	3		GPE	Mensuel		
 Les Échos Week-End	Média	3		GPE	Hebdomadaire		
 Radio Classique	Média	3		Radio	National		
-L'Opinion	Média	3		GPE	Quotidien		
 Famille Bettencourt	Personne physique	1	2				
 Nicolas Beytout	Personne physique	1					
 Patrick Drahi	Personne physique	1	8				


### PR DESCRIPTION
Le média "L'Opinion" était doublé à la ligne 9 et 53.