### PR TITLE
Mauvais typeCode pour le Monde SA

### DIFF
--- a/medias_francais.tsv
+++ b/medias_francais.tsv
@@ -11,7 +11,7 @@ Prisa	Personne morale	2
 Xavier Niel	Personne physique	1	10				
 Matthieu Pigasse	Personne physique	1					
 Le Monde libre	Personne morale	2					
-Le Monde SA	Personne morale	1					
+Le Monde SA	Personne morale	2					
 L'Obs	Média	3		GPE	Hebdomadaire		
 Prier	Média	3		GPE	Mensuel		
 M, le magazine du Monde	Média	3		GPE	Hebdomadaire		


### PR DESCRIPTION
Le Monde SA est de typeLibelle "Personne morale" donc de typeCode 2. 