### PR TITLE
Fix France info/France Info + typo

### DIFF
--- a/medias_francais.tsv
+++ b/medias_francais.tsv
@@ -75,7 +75,7 @@ id	nom	typeLibelle	typeCode	rangChallenges	mediaType	mediaPeriodicite	mediaEchel
 75	RFM	Média	3		Radio		National	
 76	Virgin Radio	Média	3		Radio		National	
 77	Vincent Bolloré	Personne physique	1	11				
-78	Financière de l‘Odet	Personne morale	2					
+78	Financière de l’Odet	Personne morale	2					
 79	Bolloré	Personne morale	2					
 80	CNews matin	Média	3		GPE	Quotidien		
 81	Vivendi	Personne morale	2					

--- a/medias_francais.tsv
+++ b/medias_francais.tsv
@@ -143,7 +143,6 @@ id	nom	typeLibelle	typeCode	rangChallenges	mediaType	mediaPeriodicite	mediaEchel
 143	France 5	Média	3		Télévision			Gratuit
 144	France 4	Média	3		Télévision			Gratuit
 145	France Ô	Média	3		Télévision			Gratuit
-146	France info	Média	3		Télévision/radio			Gratuit
 147	France Inter	Média	3		Radio		National	
 148	France Musique	Média	3		Radio		National	
 149	France Culture	Média	3		Radio		National	

--- a/relations_medias_francais.tsv
+++ b/relations_medias_francais.tsv
@@ -138,7 +138,7 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 134	France Télévision	100	France 5			
 134	France Télévision	100	France 4			
 134	France Télévision	100	France Ô			
-134	France Télévision	contrôle	France info			
+134	France Télévision	contrôle	France Info			
 135	Radio France	100	France Inter			
 135	Radio France	100	France Musique			
 135	Radio France	100	France Culture			
@@ -146,7 +146,7 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 135	Radio France	100	France Bleu			
 135	Radio France	100	France Info			
 135	Radio France	100	Mouv’			
-135	Radio France	contrôle	France info			
+135	Radio France	contrôle	France Info			
 136	Arte France	50	Arte			
 129	République fédérale d’Allemagne	contrôle	ARD / ZDF			
 155	ARD / ZDF	50	Arte Deutschland TV GmbH			

--- a/relations_medias_francais.tsv
+++ b/relations_medias_francais.tsv
@@ -76,7 +76,7 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 70	Lagardère Active	100	RFM	lagardere.com	31/12/2015	14/05/2016
 70	Lagardère Active	100	Virgin Radio	lagardere.com	31/12/2015	14/05/2016
 77	Vincent Bolloré	49,77	Financière de l’Odet			
-78	Financière de l‘Odet	64,4	Bolloré			
+78	Financière de l’Odet	64,4	Bolloré			
 79	Bolloré	100	CNews matin	bollore.com, vivendi.com, ozap.com	31/12/2015, 21/04/2017, 31/12/2015	28/06/2016 , 10/10/2016
 79	Bolloré	20,65	Vivendi	bollore.com, vivendi.com, ozap.com	31/12/2015, 21/04/2017, 31/12/2015	28/06/2016 , 10/10/2016
 81	Vivendi	100	Canal +	bollore.com, vivendi.com, ozap.com	31/12/2015, 21/04/2017, 31/12/2015	28/06/2016 , 10/10/2016


### PR DESCRIPTION
Bonjour, 
Merci d'avoir ouvert ce dataset de manière exploitable ! 👍 
J'ai corrigé une entité qui était en doublon: `France info` et `France Info` et une apostrophe qui était n'était pas accordée aux autres.
