### PR TITLE
suppression de Gruner + Jahr des relations

### DIFF
--- a/relations_medias_francais.tsv
+++ b/relations_medias_francais.tsv
@@ -105,9 +105,7 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 96	Artémis	100	Point de vue	Pressenews.fr	22/11/2017	23/11/2017
 97	Groupe Sebdo-Le Point	100	Le Point	groupeartemis.com, agefi.fr		28/06/2016
 102	Famille Mohn	contrôle	Bertelsmann			
-103	Bertelsmann	100	Gruner + Jahr			
 103	Bertelsmann	75	RTL Group			
-104	Gruner + Jahr	0	Prisma Media			
 105	RTL Group	48	Groupe M6			
 106	Prisma Media	100	Capital	investir.lesechos.fr	06/10/2014	14/05/2016
 106	Prisma Media	100	Harvard Business Review	investir.lesechos.fr	06/10/2014	14/05/2016


### PR DESCRIPTION
Je propose de supprimer deux relations : 

- `103	Bertelsmann	100	Gruner + Jahr`
- `104	Gruner + Jahr	0	Prisma Media`

En effet la relation à 0% est correcte puisque c’est maintenant Vivendi qui possède intégralement Prisma Media. Mais sa présence en tant que seule relation à 0% est plutot un bug et une exception à mon avis : la liste des relations à 0% est par définition infinie :) 

une fois cette ligne supprimée on peut remonter le fil et supprimer la relation entre Bertelsmann et Gruner + Jahr puisque Gruner + Jahr n’avait de relation qu’avec Prisma Media, on n’a donc plus de raison de garder de trace de cette entité.