### PR TITLE
Correction Perdriel ne possède que 60% et pas 100% du Groupe

### DIFF
--- a/relations_medias_francais.tsv
+++ b/relations_medias_francais.tsv
@@ -1,5 +1,5 @@
 id	origine	valeur	cible	source	datePublication	dateConsultation
-1	Claude Perdriel	contrôle	Groupe Perdriel			
+1	Claude Perdriel	60	Groupe Perdriel			
 1	Claude Perdriel	participe	Groupe L’Opinion	challenges.fr	22/08/2014	06/11/2019
 2	Sophia Publications	100	Historia	strategies.fr	14/11/2014	28/06/2016
 2	Sophia Publications	100	L’histoire	lemonde.fr	23/06/2016	22/10/2016


### PR DESCRIPTION
LVMH possède 40% du groupe Perdriel, cf https://www.challenges.fr/media/lvmh-prend-40-de-challenges_764376 

C’est déjà bien indiqué dans les relations. En revanche, il est toujours indiqué que Claude Perdriel "contrôle" le groupe dans une autre relation, ce que je comprends comme "contrôle à 100%". J’ai modifié cette relation pour indiquer `60` plutôt que `controle`. Si c’est ma compréhension de `controle` qui est fausse, pouvez-vous m’indiquer ce que signifie `controle` ou `possede` dans les relations, par rapport aux valeurs chiffrées ? merci ! 
