### PR TITLE
supression journal cnews ne paraissant plus

### DIFF
--- a/medias_francais.tsv
+++ b/medias_francais.tsv
@@ -77,7 +77,6 @@ id	nom	typeLibelle	typeCode	rangChallenges	milliardaireForbes	mediaType	mediaPer
 77	Vincent Bolloré	Personne physique	1	13	316					
 78	Financière de l’Odet	Personne morale	2							
 79	Bolloré	Personne morale	2							
-80	CNews	Média	3			GPE	Quotidien			
 81	Vivendi	Personne morale	2							
 82	Canal +	Média	3			Télévision			Payant	
 83	C8	Média	3			Télévision			Gratuit	

--- a/relations_medias_francais.tsv
+++ b/relations_medias_francais.tsv
@@ -83,7 +83,6 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 70	Lagardère News	100	Virgin Radio	lagardere.com	31/12/2015	14/05/2016
 77	Vincent Bolloré	49,77	Financière de l’Odet			
 78	Financière de l’Odet	64,4	Bolloré			
-79	Bolloré	100	CNews matin	bollore.com, vivendi.com, ozap.com	31/12/2015, 21/04/2017, 31/12/2015	28/06/2016 , 10/10/2016
 79	Bolloré	27	Vivendi	bollore.com, vivendi.com, ozap.com	31/12/2015, 21/04/2017, 31/12/2015	28/06/2016 , 10/10/2016
 79	Bolloré	100	France Catholique			
 81	Vivendi	100	C8	bollore.com, vivendi.com, ozap.com	31/12/2015, 21/04/2017, 31/12/2015	28/06/2016 , 10/10/2016


### PR DESCRIPTION
Le journal CNews (anciennement cnews matin) ne parait plus depuis 2021 (source lemonde.fr cf archive https://archive.wikiwix.com/cache/index2.php?url=https%253A%252F%252Fwww.lemonde.fr%252Factualite-medias%252Farticle%252F2021%252F11%252F30%252Fle-journal-papier-cnews-a-cesse-de-paraitre_6104216_3236.html )

de plus dans les relations la cible était "CNews matin" alors que dans le fichier d’entités le nom était "CNews" tout court ce qui posait souci pour faire les liens.