### PR TITLE
mise a jour des actionnaires de Lagardere SA

### DIFF
--- a/medias_francais.tsv
+++ b/medias_francais.tsv
@@ -321,7 +321,6 @@ id	nom	typeLibelle	typeCode	rangChallenges	milliardaireForbes	mediaType	mediaPer
 327	RMC Story	Média	3			Télévision			Gratuit	
 328	Nice-Matin	Personne morale	2							
 329	Fonds de Dotation pour une Presse Indépendante	Personne morale	2							
-330	Amber Capital	Personne morale	2							
 331	Lagardère Capital & Management	Personne morale	2							
 332	Var-Matin	Média	3			GPE	Quotidien	Régional		42070
 333	Monaco-Matin	Média	3			GPE	Quotidien	Régional		
@@ -339,3 +338,4 @@ id	nom	typeLibelle	typeCode	rangChallenges	milliardaireForbes	mediaType	mediaPer
 345	France Catholique	Média	3			GPE		National	Payant	
 346	Franc-Tireur	Média	3			GPE		National	Payant	
 347	Néon	Média	3			GPE		National	Payant	
+347	Agache SCA	Personne morale	2							

--- a/relations_medias_francais.tsv
+++ b/relations_medias_francais.tsv
@@ -41,8 +41,9 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 37	Groupe Figaro	100	La Lettre de l’Expansion	dassault.fr, offremedia.com	03/10/2017	14/05/2016 , 16/10/2017
 37	Groupe Figaro	100	Le Figaro	dassault.fr, offremedia.com	03/10/2017	14/05/2016 , 16/10/2017
 37	Groupe Figaro	100	Le Particulier	dassault.fr, offremedia.com	03/10/2017	14/05/2016 , 16/10/2017
-42	Bernard Arnault	46,6	LVMH			
 42	Bernard Arnault	27	Lagardère Capital & Management			
+42	Bernard Arnault	contrôle	Agache SCA	wikipedia.org		19/07/2023
+348	Agache SCA	48,18	LVMH	wikipedia.org		19/07/2023
 43	LVMH	40	Groupe Perdriel			
 43	LVMH	100	Aujourd’hui en France	lvmh.fr	31/12/2015	28/06/2016
 43	LVMH	100	Groupe Les Échos	lvmh.fr	31/12/2015	28/06/2016
@@ -71,11 +72,11 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 61	Altice Média	100	RMC Story	https://fr.wikipedia.org/wiki/RMC_Story		13/11/2019
 61	Altice Média	100	RMC	investir.lesechos.fr	02/02/2016	14/05/2016
 61	Altice Média	100	RMC Découverte	investir.lesechos.fr	02/02/2016	14/05/2016
-67	Arnaud Lagardère	7,96	Lagardère SA			
-67	Arnaud Lagardère	73	Lagardère Capital & Management			
-68	Qatar Investment Authority	12,83	Lagardère SA			
+67	Arnaud Lagardère	11,11	Lagardère SA	lagardere.com	31/12/2022	19/07/2023
+68	Qatar Investment Authority	11,52	Lagardère SA	lagardere.com	31/12/2022	19/07/2023
 69	Lagardère SA	100	Lagardère News			
-81	Vivendi	27,6	Lagardère SA			
+81	Vivendi	57,66	Lagardère SA	lagardere.com	31/12/2022	19/07/2023
+348	Agache SCA	7,97	Lagardère SA	lagardere.com	31/12/2022	19/07/2023
 70	Lagardère News	100	Europe 1	lagardere.com	31/12/2015	14/05/2016
 70	Lagardère News	100	Le Journal du dimanche	lagardere.com	31/12/2015	14/05/2016
 70	Lagardère News	100	Paris Match	lagardere.com	31/12/2015	14/05/2016
@@ -316,7 +317,6 @@ id	origine	valeur	cible	source	datePublication	dateConsultation
 328	Nice-Matin	100	Monaco-Matin			
 328	Nice-Matin	100	France-Antilles			
 328	Nice-Matin	100	France-Guyane			
-330	Amber Capital	20	Lagardère SA			
 81	Vivendi	100	Prisma Media			
 327	NJJ	100	Paris-Turf			
 343	Czech Media Invest	100	Télé 7 Jours			


### PR DESCRIPTION
MaJ avec les données venant d’un CP de lagardere du 31/12/2022 visible sur la page wikipedia de [Lagardere SA](https://fr.wikipedia.org/wiki/Lagard%C3%A8re_(entreprise)#Actionnariat)

<img width="520" alt="Screenshot 2023-07-19 at 17 09 49" src="https://github.com/mdiplo/Medias_francais/assets/883348/8db73e86-886d-4ca5-a1d2-17bd6bed821c">

Amber Capital n’a plus de parts dans le groupe lagardere, il disparait donc de la liste des medias car c’etait sa seule relation

J’introduis aussi Agache SCA qui est la holding de Bernard Arnault, mais je ne suis pas tout a fait sur de sa position et des parts entre les membres de la famille Arnault, et LVMH 